### PR TITLE
Use shared Renovate configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+jobs:
+  markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🧼 lint markdown files
+        uses: avto-dev/markdown-lint@v1.5.0
+
+  json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🧼 lint json files
+        uses: ocular-d/json-linter@0.0.2
+
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🧼 lint renovate config
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.2
+        with:
+          config_file_path: "renovate.json"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "github>wbaldoumas/renovate-config"
   ]
 }


### PR DESCRIPTION
## Description

- Swap to using a shared Renovate config.
- Add linting for markdown, JSON, and Renovate files.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe) - change Renovate config preset

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/atrea-policyengine/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
